### PR TITLE
Fix rgb camera for mac

### DIFF
--- a/metadrive/component/sensors/rgb_camera.py
+++ b/metadrive/component/sensors/rgb_camera.py
@@ -40,7 +40,7 @@ class RGBCamera(BaseCamera):
         self.manager = FilterManager(self.buffer, self.cam)
         fbprops = p3d.FrameBufferProperties()
         fbprops.float_color = True
-        # fbprops.set_rgba_bits(16, 16, 16, 16)
+        fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
         # fbprops.set_multisamples(16)
         self.scene_tex = p3d.Texture()

--- a/metadrive/component/sensors/rgb_camera.py
+++ b/metadrive/component/sensors/rgb_camera.py
@@ -6,6 +6,7 @@ from metadrive.component.sensors.base_camera import BaseCamera
 from metadrive.constants import CamMask
 from metadrive.constants import Semantics, CameraTagStateKey
 from metadrive.third_party.simplepbr import _load_shader_str
+from metadrive.utils.utils import is_mac
 
 
 class RGBCamera(BaseCamera):
@@ -39,15 +40,17 @@ class RGBCamera(BaseCamera):
         self.manager = FilterManager(self.buffer, self.cam)
         fbprops = p3d.FrameBufferProperties()
         fbprops.float_color = True
-        fbprops.set_rgba_bits(16, 16, 16, 16)
+        # fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
-        fbprops.set_multisamples(16)
+        # fbprops.set_multisamples(16)
         self.scene_tex = p3d.Texture()
         self.scene_tex.set_format(p3d.Texture.F_rgba16)
         self.scene_tex.set_component_type(p3d.Texture.T_float)
         self.tonemap_quad = self.manager.render_scene_into(colortex=self.scene_tex, fbprops=fbprops)
         #
         defines = {}
+        if is_mac():
+            defines["USE_330"] = True
         #
         post_vert_str = _load_shader_str('post.vert', defines)
         post_frag_str = _load_shader_str('tonemap.frag', defines)

--- a/metadrive/component/sensors/rgb_camera.py
+++ b/metadrive/component/sensors/rgb_camera.py
@@ -42,7 +42,10 @@ class RGBCamera(BaseCamera):
         fbprops.float_color = True
         fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
-        # fbprops.set_multisamples(16)
+        if is_mac():
+          fbprops.set_multisamples(4)
+        else:
+          fbprops.set_multisamples(16)
         self.scene_tex = p3d.Texture()
         self.scene_tex.set_format(p3d.Texture.F_rgba16)
         self.scene_tex.set_component_type(p3d.Texture.T_float)

--- a/metadrive/engine/core/engine_core.py
+++ b/metadrive/engine/core/engine_core.py
@@ -106,8 +106,9 @@ class EngineCore(ShowBase.ShowBase):
       loadPrcFileData("", "gl-version 4 1")
       loadPrcFileData("", "color-bits 8 8 8")
       loadPrcFileData("", "alpha-bits 8")
+      loadPrcFileData("", "framebuffer-multisample 1")
+      loadPrcFileData("", "multisamples 4")
     else:
-      # anti-aliasing does not work on macOS
       loadPrcFileData("", "framebuffer-multisample 1")
       loadPrcFileData("", "multisamples 8")
       loadPrcFileData("", "color-bits 16 16 16")
@@ -299,7 +300,7 @@ class EngineCore(ShowBase.ShowBase):
             else:
                 if is_mac():
                     self.pbrpipe = init(
-                        msaa_samples = 0,
+                        msaa_samples = 4,
                         # use_hardware_skinning=True,
                         use_330=True
                     )

--- a/metadrive/engine/core/engine_core.py
+++ b/metadrive/engine/core/engine_core.py
@@ -104,11 +104,14 @@ class EngineCore(ShowBase.ShowBase):
     if is_mac():
       # latest macOS supported openGL version
       loadPrcFileData("", "gl-version 4 1")
-      loadPrcFileData("", " framebuffer-srgb truein")
+      loadPrcFileData("", "color-bits 8 8 8")
+      loadPrcFileData("", "alpha-bits 8")
     else:
       # anti-aliasing does not work on macOS
       loadPrcFileData("", "framebuffer-multisample 1")
       loadPrcFileData("", "multisamples 8")
+      loadPrcFileData("", "color-bits 16 16 16")
+      loadPrcFileData("", "alpha-bits 16")
 
     def __init__(self, global_config):
         # if EngineCore.global_config is not None:
@@ -294,7 +297,13 @@ class EngineCore(ShowBase.ShowBase):
                 if self.global_config["daytime"] is not None:
                     self.render_pipeline.daytime_mgr.time = self.global_config["daytime"]
             else:
-                if not is_mac():
+                if is_mac():
+                    self.pbrpipe = init(
+                        msaa_samples = 0,
+                        # use_hardware_skinning=True,
+                        use_330=True
+                    )
+                else:
                     self.pbrpipe = init(
                         msaa_samples=16,
                         use_hardware_skinning=True,

--- a/metadrive/engine/core/engine_core.py
+++ b/metadrive/engine/core/engine_core.py
@@ -104,15 +104,11 @@ class EngineCore(ShowBase.ShowBase):
     if is_mac():
       # latest macOS supported openGL version
       loadPrcFileData("", "gl-version 4 1")
-      loadPrcFileData("", "color-bits 8 8 8")
-      loadPrcFileData("", "alpha-bits 8")
       loadPrcFileData("", "framebuffer-multisample 1")
       loadPrcFileData("", "multisamples 4")
     else:
       loadPrcFileData("", "framebuffer-multisample 1")
       loadPrcFileData("", "multisamples 8")
-      loadPrcFileData("", "color-bits 16 16 16")
-      loadPrcFileData("", "alpha-bits 16")
 
     def __init__(self, global_config):
         # if EngineCore.global_config is not None:

--- a/metadrive/third_party/simplepbr/__init__.py
+++ b/metadrive/third_party/simplepbr/__init__.py
@@ -265,7 +265,7 @@ class Pipeline:
 
         fbprops = p3d.FrameBufferProperties()
         fbprops.float_color = True
-        fbprops.set_rgba_bits(16, 16, 16, 16)
+        # fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
         fbprops.set_multisamples(self.msaa_samples)
         scene_tex = p3d.Texture()

--- a/metadrive/third_party/simplepbr/__init__.py
+++ b/metadrive/third_party/simplepbr/__init__.py
@@ -265,7 +265,7 @@ class Pipeline:
 
         fbprops = p3d.FrameBufferProperties()
         fbprops.float_color = True
-        # fbprops.set_rgba_bits(16, 16, 16, 16)
+        fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
         fbprops.set_multisamples(self.msaa_samples)
         scene_tex = p3d.Texture()

--- a/metadrive/third_party/simplepbr/shaders/tonemap.frag.glsl
+++ b/metadrive/third_party/simplepbr/shaders/tonemap.frag.glsl
@@ -1,13 +1,11 @@
-#version 120
+#version 330
 
 uniform sampler2D tex;
 uniform float exposure;
 
 varying vec2 v_texcoord;
 
-#ifdef USE_330
 out vec4 o_color;
-#endif
 
 void main() {
     vec3 color = texture(tex, v_texcoord).rgb;
@@ -16,9 +14,5 @@ void main() {
     color = max(vec3(0.0), color - vec3(0.004));
     color = (color * (vec3(6.2) * color + vec3(0.5))) / (color * (vec3(6.2) * color + vec3(1.7)) + vec3(0.06));
 
-#ifdef USE_330
     o_color = vec4(color, 1.0);
-#else
-    gl_FragColor = vec4(color, 1.0);
-#endif
 }

--- a/metadrive/third_party/simplepbr/shaders/tonemap.frag.glsl
+++ b/metadrive/third_party/simplepbr/shaders/tonemap.frag.glsl
@@ -10,7 +10,7 @@ out vec4 o_color;
 #endif
 
 void main() {
-    vec3 color = texture2D(tex, v_texcoord).rgb;
+    vec3 color = texture(tex, v_texcoord).rgb;
 
     color *= exposure;
     color = max(vec3(0.0), color - vec3(0.004));


### PR DESCRIPTION
## What changes do you make in this PR?

Make the `RGBCamera` work on MacOS:

`python -m metadrive.examples.drive_in_single_agent_env --observation rgb_camera`

Changes for MacOS:
* ~~Request only 8-bit colors~~
* Use GLSL 330
* Use PBR render pipeline

Required for completing: https://github.com/commaai/openpilot/issues/33207