### PR TITLE
Fix KeyError for traffic vehicles missing render_vehicle config

### DIFF
--- a/metadrive/component/vehicle/base_vehicle.py
+++ b/metadrive/component/vehicle/base_vehicle.py
@@ -139,7 +139,7 @@ class BaseVehicle(BaseObject, BaseVehicleState):
         self.set_metadrive_type(MetaDriveType.VEHICLE)
         use_special_color = self.config["use_special_color"]
 
-        self.render_vehicle = vehicle_config["render_vehicle"]
+        self.render_vehicle = self.config["render_vehicle"]
 
         # build vehicle physics model
         vehicle_chassis = self._create_vehicle_chassis()


### PR DESCRIPTION
## Problem

When `traffic_density > 0`, spawning traffic vehicles fails with:
```
KeyError: 'render_vehicle'
```
at `metadrive/component/vehicle/base_vehicle.py` line 142.

## Root Cause

In `BaseVehicle.__init__`, line 142 accesses the passed `vehicle_config` parameter directly:
```python
self.render_vehicle = vehicle_config["render_vehicle"]
```

However, the config merging happens just before this:
1. Line 136: `BaseObject.__init__(..., self.engine.global_config["vehicle_config"])` - initializes `self._config` with the global vehicle_config (which includes `render_vehicle=True`)
2. Line 138: `self.update_config(vehicle_config)` - merges the passed config into `self._config`

For the main agent vehicle, the passed `vehicle_config` includes `render_vehicle`, so it works. But for traffic vehicles, the passed config only contains spawn info from `traffic_vehicle_config` (spawn_lane_index, spawn_longitude, etc.) - it doesn't include `render_vehicle`.

After the merge, `self.config["render_vehicle"]` correctly contains `True` inherited from the base config, but `vehicle_config["render_vehicle"]` fails because the key was never in the passed parameter.

## Fix

Use `self.config["render_vehicle"]` instead of `vehicle_config["render_vehicle"]`, consistent with how `use_special_color` is accessed on line 140.