### PR TITLE
sync terrain shader texture2D -> texture from main

### DIFF
--- a/metadrive/shaders/terrain.frag.glsl
+++ b/metadrive/shaders/terrain.frag.glsl
@@ -201,7 +201,7 @@ void main() {
         float radius = 0.001; // Sample radius
         for(int x = -1; x <= 1; x++) {
             for(int y = -1; y <= 1; y++) {
-                float depth_sample = texture2D(PSSMShadowAtlas, projected_coord.xy + vec2(x, y) * radius).r;
+                float depth_sample = texture(PSSMShadowAtlas, projected_coord.xy + vec2(x, y) * radius).r;
                 shadow_factor += step(ref_depth, depth_sample);
         }
         }


### PR DESCRIPTION
terrain.frag.glsl on minimal uses deprecated `texture2D()` in a `#version 330` shader. macos enforces glsl 3.30 core profile where `texture2D` is removed, breaking terrain/road rendering in sim.

this change already exists on main via 0dd67b8a. file content checked out directly from that commit.