### PR TITLE
fix terrain shader on macOS (texture2D to texture)

### DIFF
--- a/metadrive/shaders/terrain.frag.glsl
+++ b/metadrive/shaders/terrain.frag.glsl
@@ -201,7 +201,7 @@ void main() {
         float radius = 0.001; // Sample radius
         for(int x = -1; x <= 1; x++) {
             for(int y = -1; y <= 1; y++) {
-                float depth_sample = texture2D(PSSMShadowAtlas, projected_coord.xy + vec2(x, y) * radius).r;
+                float depth_sample = texture(PSSMShadowAtlas, projected_coord.xy + vec2(x, y) * radius).r;
                 shadow_factor += step(ref_depth, depth_sample);
         }
         }


### PR DESCRIPTION
## What changes do you make in this PR?

Apple's GLSL compiler rejects legacy `texture2D()` in `#version 330`, so the terrain (including the road) never renders on macOS. Linux drivers tolerate it, which is why this only shows up on Macs.

* Please describe why you create this PR

Already fixed in upstream but the current fork version doesn't include it. Needed for commaai/openpilot#33207.

## Checklist

* [x] I have merged the latest main branch into current branch.
* [x] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
